### PR TITLE
Better handle whitespace around comments

### DIFF
--- a/src/util/publicFunctions.js
+++ b/src/util/publicFunctions.js
@@ -199,6 +199,16 @@ const hasNoNewlines = s => {
 
 const hasAtLeastTwoNewlines = s => countNewlines(s) >= 2;
 
+const normalizeWhitespace = whitespace => {
+    const numNewlines = countNewlines(whitespace);
+    if (numNewlines > 0) {
+        // Normalize to one/two newline(s)
+        return numNewlines > 1 ? [hardline, hardline] : [hardline];
+    }
+    // Normalize to one single space
+    return [line];
+};
+
 const createTextGroups = (
     s,
     preserveLeadingWhitespace,
@@ -219,12 +229,11 @@ const createTextGroups = (
                     index === len - 1 ||
                     (index === len - 2 && parts[len - 1] === "");
                 // Remove leading whitespace if allowed
-                if (isFirst && preserveLeadingWhitespace) {
-                    // Normalize to one single space
-                    currentGroup.push(line);
-                } else if (isLast && preserveTrailingWhitespace) {
-                    // Remove trailing whitespace if allowed
-                    currentGroup.push(line);
+                if (
+                    (isFirst && preserveLeadingWhitespace) ||
+                    (isLast && preserveTrailingWhitespace)
+                ) {
+                    currentGroup.push(...normalizeWhitespace(curr));
                 } else if (!isFirst && !isLast) {
                     const numNewlines = countNewlines(curr);
                     if (numNewlines <= 1) {
@@ -326,6 +335,9 @@ const isInlineElement = node => {
     );
 };
 
+const isCommentNode = node =>
+    Node.isTwigComment(node) || Node.isHtmlComment(node);
+
 const createInlineMap = nodes => nodes.map(node => isInlineElement(node));
 
 const textStatementsOnlyNewlines = nodes => {
@@ -338,14 +350,18 @@ const textStatementsOnlyNewlines = nodes => {
 
 const addPreserveWhitespaceInfo = (inlineMap, nodes) => {
     nodes.forEach((node, index) => {
+        const previousNodeIsComment =
+            index > 0 && isCommentNode(nodes[index - 1]);
+        const followingNodeIsComment =
+            index < nodes.length - 1 && isCommentNode(nodes[index + 1]);
         if (Node.isPrintTextStatement(node)) {
             const hasPreviousInlineElement = index > 0 && inlineMap[index - 1];
-            if (hasPreviousInlineElement) {
+            if (hasPreviousInlineElement || previousNodeIsComment) {
                 node[PRESERVE_LEADING_WHITESPACE] = true;
             }
             const hasFollowingInlineElement =
                 index < inlineMap.length - 1 && inlineMap[index + 1];
-            if (hasFollowingInlineElement) {
+            if (hasFollowingInlineElement || followingNodeIsComment) {
                 node[PRESERVE_TRAILING_WHITESPACE] = true;
             }
         }

--- a/tests/Comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Comments/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`htmlComments.melody.twig 1`] = `
+<!-- I am a comment -->
+This is a paragraph
+
+<!-- I am a second comment -->
+
+Another paragraph
+
+<!-- I am a third comment -->
+
+
+A third paragraph
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<!-- I am a comment -->
+This is a paragraph
+
+<!-- I am a second comment -->
+
+Another paragraph
+
+<!-- I am a third comment -->
+
+A third paragraph
+
+`;
+
 exports[`twig-comments.melody.twig 1`] = `
 {# One #}
 

--- a/tests/Comments/htmlComments.melody.twig
+++ b/tests/Comments/htmlComments.melody.twig
@@ -1,0 +1,11 @@
+<!-- I am a comment -->
+This is a paragraph
+
+<!-- I am a second comment -->
+
+Another paragraph
+
+<!-- I am a third comment -->
+
+
+A third paragraph

--- a/tests/Failing/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Failing/__snapshots__/jsfmt.spec.js.snap
@@ -50,7 +50,8 @@ exports[`controversial.melody.twig 1`] = `
 <!-- Always break objects -->
 <section class="{{ { base: css.prices } | classes }}"></section>
 
-<!-- This is what happens if we reduce indentation depth here: "as" and object keys at same indentation level -->
+<!-- This is what happens if we reduce indentation depth here: "as" and object keys at same indentation level
+    -->
 <article>
     {% mount '@hotelsearch/accommodation-list/src/Slideout/index'
         as 'accommodation-slideout-' ~ accommodation.id.id with {


### PR DESCRIPTION
Previously, newlines around comments were often dropped, making the source code layout ugly. This PR adds functionality to preserve up to 2 newlines around HTML and Twig comments.