### PR TITLE
Add printing of declarations

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -56,8 +56,8 @@ const createConfiguredParser = (code, ...extensions) => {
         {
             ignoreComments: false,
             ignoreHtmlComments: false,
-            decodeEntities: false,
-            source: code
+            ignoreDeclarations: false,
+            decodeEntities: false
         }
     );
     configureParser(parser, ...extensions);

--- a/src/print/Declaration.js
+++ b/src/print/Declaration.js
@@ -1,0 +1,16 @@
+const prettier = require("prettier");
+const { fill, join } = prettier.doc.builders;
+const { STRING_NEEDS_QUOTES, OVERRIDE_QUOTE_CHAR } = require("../util");
+
+const p = (node, path, print) => {
+    node[STRING_NEEDS_QUOTES] = true;
+    node[OVERRIDE_QUOTE_CHAR] = '"';
+    const start = "<!" + (node.declarationType || "").toUpperCase();
+    const printedParts = path.map(print, "parts");
+
+    return fill([start, " ", join(" ", printedParts), ">"]);
+};
+
+module.exports = {
+    printDeclaration: p
+};

--- a/src/print/StringLiteral.js
+++ b/src/print/StringLiteral.js
@@ -1,7 +1,8 @@
 const {
     firstValueInAncestorChain,
     quoteChar,
-    STRING_NEEDS_QUOTES
+    STRING_NEEDS_QUOTES,
+    OVERRIDE_QUOTE_CHAR
 } = require("../util");
 
 const p = (node, path, print, options) => {
@@ -12,9 +13,16 @@ const p = (node, path, print, options) => {
         STRING_NEEDS_QUOTES,
         false
     );
+    const overridingQuoteChar = firstValueInAncestorChain(
+        path,
+        OVERRIDE_QUOTE_CHAR,
+        null
+    );
 
     if (needsQuotes) {
-        const quote = quoteChar(options);
+        const quote = overridingQuoteChar
+            ? overridingQuoteChar
+            : quoteChar(options);
         return quote + node.value + quote;
     }
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -39,6 +39,7 @@ const { printImportDeclaration } = require("./print/ImportDeclaration.js");
 const { printFromStatement } = require("./print/FromStatement.js");
 const { printTwigComment } = require("./print/TwigComment.js");
 const { printHtmlComment } = require("./print/HtmlComment.js");
+const { printDeclaration } = require("./print/Declaration.js");
 const {
     printMacroDeclarationStatement
 } = require("./print/MacroDeclarationStatement.js");
@@ -262,6 +263,7 @@ printFunctions["FromStatement"] = printFromStatement;
 printFunctions["MacroDeclarationStatement"] = printMacroDeclarationStatement;
 printFunctions["TwigComment"] = printTwigComment;
 printFunctions["HtmlComment"] = printHtmlComment;
+printFunctions["Declaration"] = printDeclaration;
 
 // Fallbacks
 printFunctions["String"] = s => s;

--- a/src/util/publicSymbols.js
+++ b/src/util/publicSymbols.js
@@ -13,6 +13,13 @@
 const STRING_NEEDS_QUOTES = Symbol("STRING_NEEDS_QUOTES");
 
 /**
+ * Set to " or '
+ * Allows a node type to determine the quote char string
+ * literals must use.
+ */
+const OVERRIDE_QUOTE_CHAR = Symbol("OVERRIDE_QUOTE_CHAR");
+
+/**
  * This signals to child nodes that an expression environment
  * {{ ... }} has not yet been opened, so they might have
  * to open one. Example: An Element node, in its attributes
@@ -56,6 +63,7 @@ const NEWLINES_ONLY = Symbol("NEWLINES_ONLY");
 
 module.exports = {
     STRING_NEEDS_QUOTES,
+    OVERRIDE_QUOTE_CHAR,
     INSIDE_OF_STRING,
     EXPRESSION_NEEDED,
     FILTER_BLOCK,

--- a/tests/Declaration/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Declaration/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`doctype.melody.twig 1`] = `
+<!DOCTYPE html>
+
+<!  DOCTYPE html>
+
+<!DOCTYPE HTML PUBLIC   "-//W3C//DTD HTML 4.01//EN"   "http://www.w3.org/TR/html4/strict.dtd">
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<!DOCTYPE html>
+
+<!DOCTYPE html>
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+
+`;

--- a/tests/Declaration/doctype.melody.twig
+++ b/tests/Declaration/doctype.melody.twig
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+
+<!  DOCTYPE html>
+
+<!DOCTYPE HTML PUBLIC   "-//W3C//DTD HTML 4.01//EN"   "http://www.w3.org/TR/html4/strict.dtd">

--- a/tests/Declaration/jsfmt.spec.js
+++ b/tests/Declaration/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["melody"]);


### PR DESCRIPTION
This PR adds printing for declarations such as `<!DOCTYPE html>`. It is related to issue #12 