### PR TITLE
Introduce twigOutputEndblockName option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -105,6 +105,12 @@ const options = {
         default: true,
         description:
             "See https://twig.symfony.com/doc/2.x/coding_standards.html"
+    },
+    twigOutputEndblockName: {
+        type: "boolean",
+        category: "Global",
+        default: false,
+        description: "Output the Twig block name in the 'endblock' tag"
     }
 };
 

--- a/src/print/BlockStatement.js
+++ b/src/print/BlockStatement.js
@@ -3,9 +3,10 @@ const { concat, hardline, group } = prettier.doc.builders;
 const { Node } = require("melody-types");
 const { EXPRESSION_NEEDED, printChildBlock } = require("../util");
 
-const p = (node, path, print) => {
+const p = (node, path, print, options) => {
     node[EXPRESSION_NEEDED] = false;
     const hasChildren = Array.isArray(node.body);
+    const printEndblockName = options.twigOutputEndblockName === true;
 
     if (hasChildren) {
         const blockName = path.call(print, "name");
@@ -23,8 +24,8 @@ const p = (node, path, print) => {
         parts.push(hardline);
         parts.push(
             node.trimLeftEndblock ? "{%-" : "{%",
-            " endblock ",
-            blockName,
+            " endblock",
+            printEndblockName ? concat([" ", blockName]) : "",
             node.trimRight ? " -%}" : " %}"
         );
 

--- a/tests/ControlStructures/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ControlStructures/__snapshots__/jsfmt.spec.js.snap
@@ -112,7 +112,7 @@ exports[`forWithBlock.melody.twig 1`] = `
         <li class="{{ loop.last ? 'last' : '' }}">
             {% block title %}
                 {{ loop.index0 }} {{ item.name|title }} {{ loop.index }}
-            {% endblock title %}
+            {% endblock %}
         </li>
     {% endfor %}
 </ul>

--- a/tests/IncludeEmbed/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/IncludeEmbed/__snapshots__/jsfmt.spec.js.snap
@@ -26,7 +26,7 @@ exports[`block.melody.twig 1`] = `
         <div key="1" class="test">
             <span>Hello</span>
         </div>
-    {% endblock hello %}
+    {% endblock %}
 </section>
 
 {% block bar foo %}
@@ -34,11 +34,11 @@ exports[`block.melody.twig 1`] = `
 {{ block('hello') }}
 
 {% block content %}
-{% endblock content %}
+{% endblock %}
 
 {%- block hello -%}
     Hello
-{%- endblock hello -%}
+{%- endblock -%}
 
 {%- block bar foo -%}
 
@@ -78,15 +78,15 @@ exports[`embed.melody.twig 1`] = `
                 {% embed 'bar.twig' -%}
                     {% block hello %}
                         {{ message }}
-                    {% endblock hello %}
+                    {% endblock %}
                     {% block test %}
 
-                    {% endblock test %}
+                    {% endblock %}
                 {%- endembed %}
-            {% endblock hello %}
+            {% endblock %}
         {% endembed -%}
     </div>
-{% endblock hello %}
+{% endblock %}
 
 `;
 

--- a/tests/Options/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Options/__snapshots__/jsfmt.spec.js.snap
@@ -10,6 +10,17 @@ exports[`alwaysBreakObjects.melody.twig 1`] = `
 
 `;
 
+exports[`endblockName.melody.twig 1`] = `
+{% block title %}
+    {{ item.name|title }}
+{% endblock %}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+{% block title %}
+    {{ item.name|title }}
+{% endblock title %}
+
+`;
+
 exports[`printWidth.melody.twig 1`] = `
 <span attr1="one" attr2="two" attr3="three" attr4="four" attr5="five" attr6="six" attr7="seven" attr8="abcd">Text</span>
 

--- a/tests/Options/endblockName.melody.twig
+++ b/tests/Options/endblockName.melody.twig
@@ -1,0 +1,3 @@
+{% block title %}
+    {{ item.name|title }}
+{% endblock %}

--- a/tests/Options/jsfmt.spec.js
+++ b/tests/Options/jsfmt.spec.js
@@ -1,4 +1,5 @@
 run_spec(__dirname, ["melody"], {
     twigAlwaysBreakObjects: false,
-    twigPrintWidth: 120
+    twigPrintWidth: 120,
+    twigOutputEndblockName: true
 });

--- a/tests/TwigCodingStandards/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/TwigCodingStandards/__snapshots__/jsfmt.spec.js.snap
@@ -61,6 +61,6 @@ exports[`twigCodingStandards.melody.twig 1`] = `
     {% if true %}
         true
     {% endif %}
-{% endblock foo %}
+{% endblock %}
 
 `;


### PR DESCRIPTION
This answers issue #22. Not everyone likes the block name in the `{% endblock %}` tag.