### PR TITLE
Choose quote character depending on string contents

### DIFF
--- a/src/print/StringLiteral.js
+++ b/src/print/StringLiteral.js
@@ -5,6 +5,34 @@ const {
     OVERRIDE_QUOTE_CHAR
 } = require("../util");
 
+const isUnmaskedOccurrence = (s, pos) => {
+    return pos === 0 || s[pos - 1] !== "\\";
+};
+
+const containsUnmasked = char => s => {
+    let pos = s.indexOf(char);
+    while (pos >= 0) {
+        if (isUnmaskedOccurrence(s, pos)) {
+            return true;
+        }
+        pos = s.indexOf(char, pos + 1);
+    }
+    return false;
+};
+
+const containsUnmaskedSingleQuote = containsUnmasked("'");
+const containsUnmaskedDoubleQuote = containsUnmasked('"');
+
+const getQuoteChar = (s, options) => {
+    if (containsUnmaskedSingleQuote(s)) {
+        return '"';
+    }
+    if (containsUnmaskedDoubleQuote(s)) {
+        return "'";
+    }
+    return quoteChar(options);
+};
+
 const p = (node, path, print, options) => {
     // The structure this string literal is part of
     // determines if we need quotes or not
@@ -13,6 +41,9 @@ const p = (node, path, print, options) => {
         STRING_NEEDS_QUOTES,
         false
     );
+    // In case of a string with interpolations, only double quotes
+    // are allowed. This is then indicated by OVERRIDE_QUOTE_CHAR
+    // in an ancestor.
     const overridingQuoteChar = firstValueInAncestorChain(
         path,
         OVERRIDE_QUOTE_CHAR,
@@ -22,7 +53,7 @@ const p = (node, path, print, options) => {
     if (needsQuotes) {
         const quote = overridingQuoteChar
             ? overridingQuoteChar
-            : quoteChar(options);
+            : getQuoteChar(node.value, options);
         return quote + node.value + quote;
     }
 

--- a/tests/Expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Expressions/__snapshots__/jsfmt.spec.js.snap
@@ -394,8 +394,24 @@ exports[`stringConcat.melody.twig 1`] = `
 
 exports[`stringLiteral.melody.twig 1`] = `
 {{ 'zzz\\\\bar\\\\baz' }}
+
+{{ "College - Women's" }}
+
+{{ "test ' with \\\\"both\\\\" kinds" }}
+
+{{ 'test \\\\' with "both" kinds' }}
+
+{{ "Quoted \\\\'' unquoted" }}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 {{ 'zzz\\\\bar\\\\baz' }}
+
+{{ "College - Women's" }}
+
+{{ "test ' with \\"both\\" kinds" }}
+
+{{ 'test \\' with "both" kinds' }}
+
+{{ "Quoted \\\\'' unquoted" }}
 
 `;
 

--- a/tests/Expressions/stringLiteral.melody.twig
+++ b/tests/Expressions/stringLiteral.melody.twig
@@ -1,1 +1,9 @@
 {{ 'zzz\\bar\\baz' }}
+
+{{ "College - Women's" }}
+
+{{ "test ' with \\"both\\" kinds" }}
+
+{{ 'test \\' with "both" kinds' }}
+
+{{ "Quoted \\'' unquoted" }}


### PR DESCRIPTION
In response to issue #24, this PR chooses the quotation characters (single or double quote) around a string literal not just depending on the `options` passed in, but also depending on the string contents:

- If the string contains unmasked single quotes, it will be surrounded by double quotes.
- If the string contains unmasked double quotes, it will be surrounded by single quotes.