### PR TITLE
No line break before %} for set, if, for

### DIFF
--- a/src/print/ForStatement.js
+++ b/src/print/ForStatement.js
@@ -17,7 +17,7 @@ const printFor = (node, path, print) => {
             indent(concat([line, "if ", path.call(print, "condition")]))
         );
     }
-    parts.push(concat([line, node.trimRightFor ? "-%}" : "%}"]));
+    parts.push(concat([" ", node.trimRightFor ? "-%}" : "%}"]));
     return group(concat(parts));
 };
 

--- a/src/print/IfStatement.js
+++ b/src/print/IfStatement.js
@@ -29,7 +29,7 @@ const p = (node, path, print) => {
             node.trimLeft ? "{%- " : "{% ",
             isElseIf ? "elseif" : "if",
             indent(concat([line, path.call(print, "test")])),
-            line,
+            " ",
             node.trimRightIf ? "-%}" : "%}"
         ])
     );

--- a/src/print/SetStatement.js
+++ b/src/print/SetStatement.js
@@ -8,7 +8,7 @@ const buildSetStatement = (node, printedAssignment) => {
             node.trimLeft ? "{%-" : "{%",
             " set ",
             printedAssignment,
-            line,
+            " ",
             node.trimRight ? "-%}" : "%}"
         ])
     );

--- a/tests/ControlStructures/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ControlStructures/__snapshots__/jsfmt.spec.js.snap
@@ -64,8 +64,7 @@ exports[`forIfElse.melody.twig 1`] = `
 
 <ul>
     {% for key, value in c[:c.length - 1]
-        if value is defined and value is not even
-    %}
+        if value is defined and value is not even %}
         <li>{{ key }} - {{ value }}</li>
     {% else -%}
         {% if regionName is empty %}

--- a/tests/Expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Expressions/__snapshots__/jsfmt.spec.js.snap
@@ -65,36 +65,30 @@ exports[`binaryExpressions.melody.twig 1`] = `
 {% set highlightValueForMoney = isFeatureEnabled('vFMV5')
     or isCTestActive('WEB-48935')
     or isCTestActive('WEB-48956')
-    or isCTestActive('WEB-48955')
-%}
+    or isCTestActive('WEB-48955') %}
 
 {% set name = condition1
     or condition2 and condition3
     or condition4
-    or condition5 and condition6
-%}
+    or condition5 and condition6 %}
 
 {% set name = condition1 and condition2
     or condition3 and condition4 and condition5
-    or condition6
-%}
+    or condition6 %}
 
 <!-- indent operators -->
 {% set replacement = {
     '$address': '<span itemprop="streetAddress">' ~ address_attributes.address
         ~ '</span>'
-}
-%}
+} %}
 
 {% set renderLoadingBar = showNewLoadingAnimation
     and isCTestActive('WEB-47697')
     and showLoadingBar
-    and (isABCD or isLoading)
-%}
+    and (isABCD or isLoading) %}
 
 {% set result = (conditionAlpha or conditionBeta)
-    and (conditionGamma or conditionDelta)
-%}
+    and (conditionGamma or conditionDelta) %}
 
 `;
 

--- a/tests/Failing/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Failing/__snapshots__/jsfmt.spec.js.snap
@@ -40,8 +40,8 @@ exports[`controversial.melody.twig 1`] = `
     {{ 'results_for' | translate({ 'searchedterm': '<mark class="highlight-search-term">' ~ semKeyword ~ '</mark>'}) | raw }}
 </p>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-{% set isRewardRate = isMarriottRewardRate or rewardRateAltIds and deal.dealId in rewardRateAltIds[accommodation.id.id]
-%}
+{% set isRewardRate = isMarriottRewardRate
+    or rewardRateAltIds and deal.dealId in rewardRateAltIds[accommodation.id.id] %}
 
 <!-- Alternatively, introduce another variable -->
 {% set altIds = rewardRateAltIds[accommodation.id.id] %}

--- a/tests/Statements/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Statements/__snapshots__/jsfmt.spec.js.snap
@@ -198,16 +198,14 @@ exports[`set.melody.twig 1`] = `
     shape: 'round',
     taste: 'sweet',
     region: 'Europe'
-}
-%}
+} %}
 {% set foo = {
     fruit: 'apple',
     shape: 'round',
     taste: 'sweet',
     region: 'Europe',
     colour: 'reddish'
-}
-%}
+} %}
 {% set foo = 'foo' %}
 {% set bar = 'bar' %}
 {%- set foo -%}
@@ -222,8 +220,7 @@ exports[`set.melody.twig 1`] = `
 
 {% set showArrows = hideArrowWhenDisabled|default(false)
     ? (shouldShowArrows|default(false)) and (scrollEnabled|default(false))
-    : shouldShowArrows|default(false)
-%}
+    : shouldShowArrows|default(false) %}
 
 {% set recommendedClickoutAttributes = hasRecommendedPrice
     ? clickoutAttributes|merge({
@@ -231,8 +228,7 @@ exports[`set.melody.twig 1`] = `
         'data-co_params': recommendedPrice.clcklB|json_encode,
         'data-co_li_lo': 1
     })
-    : {}
-%}
+    : {} %}
 
 `;
 


### PR DESCRIPTION
By adding a potential breaking point before the closing `%}`, there were some strange effects sometimes. For example:
```
{% set replacement = {
    '$address': '<span itemprop="streetAddress">' ~ address_attributes.address
        ~ '</span>'
}
%}
```
The `%}` in its own line here does not look right. Therefore, in this PR, the breaking point was removed for the `set`, `for`, and `if` tags.