### PR TITLE
Turn the twigMelodyPlugins option into an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Values can be `true` or `false`. If `true`, single quotes will be used for strin
 
 An array containing file paths to plugin directories. This can be used to add your own printers and parser extensions.
 
-Example:
+The paths are relative paths, seen from the project root. Example:
 
 ```
 "twigMelodyPlugins": ["src-js/some-melody-plugin", "src-js/some-other-plugin"]

--- a/README.md
+++ b/README.md
@@ -36,9 +36,15 @@ This Prettier plugin comes with some options that you can add to your Prettier c
 
 Values can be `true` or `false`. If `true`, single quotes will be used for string literals in Twig files.
 
-### twigMelodyPlugins (default: `""`)
+### twigMelodyPlugins (default: `[]`)
 
 An array containing file paths to plugin directories. This can be used to add your own printers and parser extensions.
+
+Example:
+
+```
+"twigMelodyPlugins": ["src-js/some-melody-plugin", "src-js/some-other-plugin"]
+```
 
 ### twigPrintWidth (default: `80`)
 

--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,8 @@ const options = {
     twigMelodyPlugins: {
         type: "path",
         category: "Global",
-        default: "",
+        array: true,
+        default: [{ value: [] }],
         description:
             "Provide additional plugins for Melody. Relative file path from the project root."
     },

--- a/src/util/pluginUtil.js
+++ b/src/util/pluginUtil.js
@@ -2,12 +2,8 @@ const path = require("path");
 const resolve = require("resolve");
 
 const getPluginPathsFromOptions = options => {
-    if (
-        options.twigMelodyPlugins &&
-        typeof options.twigMelodyPlugins === "string"
-    ) {
-        const paths = options.twigMelodyPlugins || "";
-        return paths.split("|").map(s => s.trim());
+    if (options.twigMelodyPlugins && Array.isArray(options.twigMelodyPlugins)) {
+        return options.twigMelodyPlugins.map(s => s.trim());
     }
     return [];
 };


### PR DESCRIPTION
Previously, the idea was that multiple `twigMelodyPlugins` could be specified as one string, separated by `|`. This PR turns the option into an array instead.