### PR TITLE
Bugfix: Filter expression in string interpolation

### DIFF
--- a/src/print/FilterExpression.js
+++ b/src/print/FilterExpression.js
@@ -3,9 +3,11 @@ const { group, concat, indent, line, softline, join } = prettier.doc.builders;
 const { Node } = require("melody-types");
 const {
     EXPRESSION_NEEDED,
+    INSIDE_OF_STRING,
     STRING_NEEDS_QUOTES,
     FILTER_BLOCK,
     shouldExpressionsBeWrapped,
+    wrapInStringInterpolation,
     someParentNode,
     isMultipartExpression,
     getDeepProperty
@@ -116,11 +118,14 @@ const p = (node, path, print, options) => {
         parts.push(indent(indentedFilters));
     }
 
-    if (shouldExpressionsBeWrapped(path)) {
-        // We manually wrap here, to avoid a line break
-        // between the curly braces
+    const kindOfWrap = shouldExpressionsBeWrapped(path);
+    if (kindOfWrap === EXPRESSION_NEEDED) {
+        // Instead of using wrapExpressionIfNeeded(), we manually
+        // wrap here, to avoid a line break between the curly braces
         parts.push(" }}");
         parts.unshift("{{ ");
+    } else if (kindOfWrap === INSIDE_OF_STRING) {
+        wrapInStringInterpolation(parts);
     }
 
     return group(concat(parts));

--- a/src/util/publicFunctions.js
+++ b/src/util/publicFunctions.js
@@ -537,6 +537,8 @@ const printChildGroups = (node, path, print, ...childPath) => {
 module.exports = {
     shouldExpressionsBeWrapped,
     wrapExpressionIfNeeded,
+    wrapInStringInterpolation,
+    wrapInEnvironment,
     findParentNode,
     isRootNode,
     isMelodyNode,

--- a/tests/Expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Expressions/__snapshots__/jsfmt.spec.js.snap
@@ -238,7 +238,7 @@ exports[`objectExpression.melody.twig 1`] = `
 <h1 class="{{ {
             ('hero__title--' ~ (locale | lower)): locale in ['CN', 'JP', 'DE', 'RU'],
         } | classes }}">Heading</h1>
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 {{
     {
         a: 'foo',
@@ -394,12 +394,19 @@ exports[`stringConcat.melody.twig 1`] = `
 </div>
 
 <span data-whitespace-test="Testing: {{- noWhitespaceTest -}} foo">Test</span>
+
+{% set calendarIcon = isNewGuestSelector ? 'icn_#{type | lower}_line_dark' : type | lower %}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <div>
     {{ first ~ second }}
 </div>
 
 <span data-whitespace-test="Testing: {{- noWhitespaceTest -}} foo">Test</span>
+
+{% set calendarIcon = isNewGuestSelector
+    ? "icn_#{type|lower}_line_dark"
+    : type|lower
+%}
 
 `;
 

--- a/tests/Expressions/objectExpression.melody.twig
+++ b/tests/Expressions/objectExpression.melody.twig
@@ -8,4 +8,3 @@
 <h1 class="{{ {
             ('hero__title--' ~ (locale | lower)): locale in ['CN', 'JP', 'DE', 'RU'],
         } | classes }}">Heading</h1>
-        

--- a/tests/Expressions/stringConcat.melody.twig
+++ b/tests/Expressions/stringConcat.melody.twig
@@ -3,3 +3,5 @@
 </div>
 
 <span data-whitespace-test="Testing: {{- noWhitespaceTest -}} foo">Test</span>
+
+{% set calendarIcon = isNewGuestSelector ? 'icn_#{type | lower}_line_dark' : type | lower %}

--- a/tests/Failing/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Failing/__snapshots__/jsfmt.spec.js.snap
@@ -84,66 +84,26 @@ exports[`controversial.melody.twig 1`] = `
 `;
 
 exports[`failing.melody.twig 1`] = `
-<li class="{{ css.item }}">
-    <div class="{{ css.priceInfo }}">
-        <span class="{{ css.miniPriceBars }}">
-            <span class="{{ {
-                    base: css.dot,
-                    (css.dotLeft): concept.medianPrice < overviewPrices.medianPrice - middleRange,
-                    (css.dotFarLeft): concept.medianPrice < overviewPrices.percentile25Price,
-                    (css.dotRight): concept.medianPrice > overviewPrices.medianPrice + middleRange,
-                    (css.dotFarRight): concept.medianPrice > overviewPrices.percentile75Price
-                } | classes }}"></span>
-            <span class="{{ css.averagePrice }}">{{ overviewPrices.medianPriceDisplay }}</span>
-        </span>
-    </div>
-</li>
-
-{#
-<select name="purchasableId" id="purchasableId" class="purchasableId">
-    {%- for purchasable in product.getVariants() -%}
-        <option {% if not purchasable.isAvailable %}disabled{% endif %}>
-            {{ purchasable.description }}
-            {{
-                purchasable.salePrice|commerceCurrency(
-                    cart.currency
-                )
-            }}
-        </option>
-    {%- endfor -%}
-</select>
+{# IF tag in element not allowed
+<option {% if not purchasable.isAvailable %}disabled{% endif %}>
+    {{ purchasable.description }}
+    {{
+        purchasable.salePrice|commerceCurrency(
+            cart.currency
+        )
+    }}
+</option>
 #}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-<li class="{{ css.item }}">
-    <div class="{{ css.priceInfo }}">
-        <span class="{{ css.miniPriceBars }}">
-            <span class="{{ {
-                    base: css.dot,
-                    (css.dotLeft): concept.medianPrice < overviewPrices.medianPrice - middleRange,
-                    (css.dotFarLeft): concept.medianPrice < overviewPrices.percentile25Price,
-                    (css.dotRight): concept.medianPrice > overviewPrices.medianPrice + middleRange,
-                    (css.dotFarRight): concept.medianPrice > overviewPrices.percentile75Price
-                } | classes }}">
-
-            </span>
-            <span class="{{ css.averagePrice }}">{{ overviewPrices.medianPriceDisplay }}</span>
-        </span>
-    </div>
-</li>
-
-{#
-<select name="purchasableId" id="purchasableId" class="purchasableId">
-    {%- for purchasable in product.getVariants() -%}
-        <option {% if not purchasable.isAvailable %}disabled{% endif %}>
-            {{ purchasable.description }}
-            {{
-                purchasable.salePrice|commerceCurrency(
-                    cart.currency
-                )
-            }}
-        </option>
-    {%- endfor -%}
-</select>
+{# IF tag in element not allowed
+<option {% if not purchasable.isAvailable %}disabled{% endif %}>
+    {{ purchasable.description }}
+    {{
+        purchasable.salePrice|commerceCurrency(
+            cart.currency
+        )
+    }}
+</option>
 #}
 
 `;

--- a/tests/Failing/failing.melody.twig
+++ b/tests/Failing/failing.melody.twig
@@ -1,29 +1,10 @@
-<li class="{{ css.item }}">
-    <div class="{{ css.priceInfo }}">
-        <span class="{{ css.miniPriceBars }}">
-            <span class="{{ {
-                    base: css.dot,
-                    (css.dotLeft): concept.medianPrice < overviewPrices.medianPrice - middleRange,
-                    (css.dotFarLeft): concept.medianPrice < overviewPrices.percentile25Price,
-                    (css.dotRight): concept.medianPrice > overviewPrices.medianPrice + middleRange,
-                    (css.dotFarRight): concept.medianPrice > overviewPrices.percentile75Price
-                } | classes }}"></span>
-            <span class="{{ css.averagePrice }}">{{ overviewPrices.medianPriceDisplay }}</span>
-        </span>
-    </div>
-</li>
-
-{#
-<select name="purchasableId" id="purchasableId" class="purchasableId">
-    {%- for purchasable in product.getVariants() -%}
-        <option {% if not purchasable.isAvailable %}disabled{% endif %}>
-            {{ purchasable.description }}
-            {{
-                purchasable.salePrice|commerceCurrency(
-                    cart.currency
-                )
-            }}
-        </option>
-    {%- endfor -%}
-</select>
+{# IF tag in element not allowed
+<option {% if not purchasable.isAvailable %}disabled{% endif %}>
+    {{ purchasable.description }}
+    {{
+        purchasable.salePrice|commerceCurrency(
+            cart.currency
+        )
+    }}
+</option>
 #}


### PR DESCRIPTION
This PR fixes a bug where the plugin was turning 
```
"icn_#{type | lower}_line_dark"
```
into 
```
'icn_{{ type | lower }}_line_dark'
```
which is invalid code.
