### PR TITLE
Add <mark> and <time> to the list of inline elements

### DIFF
--- a/src/util/publicFunctions.js
+++ b/src/util/publicFunctions.js
@@ -18,12 +18,14 @@ const INLINE_HTML_ELEMENTS = [
     "em",
     "i",
     "li",
+    "mark",
     "s",
     "strong",
     "sup",
     "sub",
     "small",
-    "span"
+    "span",
+    "time"
 ];
 
 /**


### PR DESCRIPTION
This prevents leading whitespace from being removed.