### PR TITLE
Force braces around conditionals when concatenating

### DIFF
--- a/src/print/BinaryExpression.js
+++ b/src/print/BinaryExpression.js
@@ -58,7 +58,9 @@ const otherNeedsParentheses = (node, otherProp) => {
         (otherPrecedence > ownPrecedence &&
             isBinaryOther &&
             hasLogicalOperator(other)) ||
-        Node.isFilterExpression(other)
+        Node.isFilterExpression(other) ||
+        (Node.isBinaryConcatExpression(node) &&
+            Node.isConditionalExpression(other))
     );
 };
 

--- a/tests/Expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/Expressions/__snapshots__/jsfmt.spec.js.snap
@@ -400,6 +400,8 @@ exports[`stringConcat.melody.twig 1`] = `
 <span data-whitespace-test="Testing: {{- noWhitespaceTest -}} foo">Test</span>
 
 {% set calendarIcon = isNewGuestSelector ? 'icn_#{type | lower}_line_dark' : type | lower %}
+
+{% icon 'name' with { classList: 'classA' ~ (not needsB ? ' classB') } %}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <div>
     {{ first ~ second }}
@@ -410,6 +412,13 @@ exports[`stringConcat.melody.twig 1`] = `
 {% set calendarIcon = isNewGuestSelector
     ? "icn_#{type|lower}_line_dark"
     : type|lower
+%}
+
+{% icon 'name'
+    with
+    {
+        classList: 'classA' ~ (not needsB ? ' classB')
+    }
 %}
 
 `;

--- a/tests/Expressions/stringConcat.melody.twig
+++ b/tests/Expressions/stringConcat.melody.twig
@@ -5,3 +5,5 @@
 <span data-whitespace-test="Testing: {{- noWhitespaceTest -}} foo">Test</span>
 
 {% set calendarIcon = isNewGuestSelector ? 'icn_#{type | lower}_line_dark' : type | lower %}
+
+{% icon 'name' with { classList: 'classA' ~ (not needsB ? ' classB') } %}


### PR DESCRIPTION
Before, the formatter would apply the following simplification:

Input:
```
  {% icon 'name' with {
      classList: 'classA' ~ (not needsB ? ' classB')
  } %}
```

Output:
```
  {% icon 'name' with {
      classList: 'classA' ~ not needsB ? ' classB'
  } %}
```

Although operator precedence should allow us to drop the braces, this
could e.g. cause the following to happen when rendering the template:

With braces:
```
  <span class="classA classB">...</span>
```

Without braces:
```
  <span class="  classB">...</span>
```

The left part of the concatenation essentially turned into a whitespace.
Now, braces are being placed around these expression combinations.