### PR TITLE
add support for vim-prettier and coc-prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 ---
 
-This Plugin enables Prettier to format `.twig` files, as well as `.html.twig` and `.melody.twig`. [Melody](https://melody.js.org) is a component based UI framework that uses Twig as its template language.
+This plugin for Prettier is a fork of [`prettier-plugin-twig-melody`](https://github.com/trivago/prettier-plugin-twig-melody), which is currently unmaintained. Several enhancements have been added to fit our development and templating needs at [Supersoniks](https://supersoniks.com/).
 
 ## Install
 
 ```bash
-yarn add --dev prettier-plugin-twig-melody
+yarn add --dev @supersoniks/prettier-plugin-twig-melody
 ```
 
 ## Use
@@ -24,143 +24,13 @@ In your editor, if the plugin is not automatically picked up and invoked (e.g., 
 {
     "printWidth": 80,
     "tabWidth": 4,
-    "plugins": ["./node_modules/prettier-plugin-twig-melody"]
+    "plugins": ["./node_modules/@supersoniks/prettier-plugin-twig-melody"]
 }
 ```
 
-## Options
+## Enhancements
 
-This Prettier plugin comes with some options that you can add to your Prettier configuration (e.g., `prettierrc.json`).
+- Preserve `only` keyword in twig templates.
+- Block statements : no empty line between opening end closing `block` statements. 
+- Html element : nno empty line between opening and closing tags. 
 
-### twigSingleQuote (default: `true`)
-
-Values can be `true` or `false`. If `true`, single quotes will be used for string literals in Twig files.
-
-### twigMelodyPlugins (default: `[]`)
-
-An array containing file paths to plugin directories. This can be used to add your own printers and parser extensions.
-
-The paths are relative paths, seen from the project root. Example:
-
-```json
-"twigMelodyPlugins": ["src-js/some-melody-plugin", "src-js/some-other-plugin"]
-```
-
-### twigPrintWidth (default: `80`)
-
-Because Twig files might have a lot of nesting, it can be useful to define a separate print width for Twig files. This can be done with this option. If it is not set, the standard `printWidth` option is used.
-
-### twigAlwaysBreakObjects (default: `false`)
-
-If set to `true`, objects will always be wrapped/broken, even if they would fit on one line:
-
-```html
-<section
-    class="{{ {
-    base: css.prices
-} | classes }}"
-></section>
-```
-
-If set to `false` (default value), this would be printed as:
-
-```html
-<section class="{{ { base: css.prices } | classes }}"></section>
-```
-
-### twigFollowOfficialCodingStandards (default: `true`)
-
-Follow the standards described in [https://twig.symfony.com/doc/2.x/coding_standards.html](https://twig.symfony.com/doc/2.x/coding_standards.html) exactly. If set to `false`, some slight deviations might occur, such as spaces around the filter `|` operator (`s | upper` instead of `s|upper`).
-
-### twigOutputEndblockName (default: `false`)
-
-Choose whether to output the block name in `{% endblock %}` tags (e.g., `{% endblock content %}`) or not. The default is not to output it.
-
-### twigMultiTags (default: `[]`)
-
-An array of coherent sequences of non-standard Twig tags that should be treated as belonging together. Example (inspired by [Craft CMS](https://docs.craftcms.com/v2/templating/nav.html)):
-
-```json
-twigMultiTags: [
-    "nav,endnav",
-    "switch,case,default,endswitch",
-    "ifchildren,endifchildren",
-    "cache,endcache"
-]
-```
-
-Looking at the case of `nav,endnav`, this means that the Twig tags `{% nav %}` and `{% endnav %}` will be treated as a pair, and everything in between will be indented:
-
-```twig
-{% nav entry in entries %}
-    <li>
-        <a href="{{ entry.url }}">{{ entry.title }}</a>
-    </li>
-{% endnav %}
-```
-
-If we did not list the `"nav,endnav"` entry in `twigMultiTags`, this code example would be printed without indentation, because `{% nav %}` and `{% endnav %}` would be treated as unrelated, individual Twig tags:
-
-```twig
-{% nav entry in entries %}
-<li>
-    <a href="{{ entry.url }}">{{ entry.title }}</a>
-</li>
-{% endnav %}
-```
-
-Note that the order matters: It has to be `"nav,endnav"`, and it must not be `"endnav,nav"`. In general, the first and the last tag name matter. In the case of `"switch,case,default,endswitch"`, the order of `case` and `default` does not matter. However, `switch` has to come first, and `endswitch` has to come last.
-
-## Features
-
-### `prettier-ignore` and `prettier-ignore-start`
-
-When you are not happy with how Prettier formats a certain element or section in the code, you can tell it to leave it in peace:
-
-```
-{# prettier-ignore #}
-<div   class="weird-formatting"   >This will not be re-formatted</div>
-
-<div   class="weird-formatting"   >But this will be</div>
-```
-
-You can also tell Prettier to leave entire regions as they are:
-
-```
-{# prettier-ignore-start #}
-    ...
-{# prettier-ignore-end #}
-```
-
-## Plugins
-
-[Melody](https://melody.js.org) features an extensible parser, so chances are you add custom elements for which the parsing and printing logic is not part of this Prettier plugin. Therefore, this Prettier plugin is itself pluggable.
-
-Let's look at an example of a plugin to the plugin:
-
-```javascript
-const melodyIconPlugin = require("../melody-plugin-icon-tag");
-
-const printIconTag = (node, path, print, options) => {
-    // Implementation of printing
-    // ...
-};
-
-module.exports = {
-    melodyExtensions: [melodyIconPlugin],
-    printers: {
-        IconTag: printIconTag
-    }
-};
-```
-
-As we can see, a plugin to the plugin exports two fields:
-
--   `melodyExtensions`: A list of extensions to the [Melody](https://melody.js.org) framework that might export `tags`, `visitors`, `functionMap` and the like. Usually, such an extension will add additional parsing functionality to the core parser.
--   `printers`: The Prettier printing functionality for your additional language constructs, tags, operators, etc. This is an object where the keys are the node types in the Melody AST (abstract syntax tree) &mdash; as retrieved through `node.constructor.name` &mdash;, and the values are the print functions with the standard Prettier signature.
-
-Don't forget to make your plugins known through the `twigMelodyPlugins` option in your Prettier configuration.
-
-## Testing
-
--   You can call `yarn test`to test against all regular tests

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
-    "name": "prettier-plugin-twig-melody",
-    "version": "0.4.6",
+    "name": "@supersoniks/prettier-plugin-twig-melody",
+    "version": "1.0.2",
     "description": "Prettier Plugin for Twig/Melody",
     "main": "src",
-    "repository": "https://github.com/trivago/prettier-plugin-twig-melody",
+    "publishConfig": {
+        "access": "public"
+    },
+    "repository": "https://github.com/AgenceSupersoniks/prettier-plugin-twig-melody",
     "author": "Tom Bartel <thomas.bartel@trivago.com>",
     "license": "Apache 2.0",
     "files": [
@@ -16,7 +19,7 @@
         "lint": "jest -c jest.eslint.config.js",
         "test": "jest",
         "prettier": "prettier --plugin=. --parser=melody",
-        "publish": "npm publish"
+        "publish": "npm publish --access public"
     },
     "dependencies": {
         "babel-types": "^6.26.0",

--- a/src/index.js
+++ b/src/index.js
@@ -16,8 +16,13 @@ const languages = [
         codemirrorMimeType: "text/melody-twig",
         extensions: [".melody.twig", ".html.twig", ".twig"],
         linguistLanguageId: 0,
-        vscodeLanguageIds: ["twig"]
-    }
+        vscodeLanguageIds: [
+            "twig",
+            "html.twig",
+            "html.twig.js.css",
+            "xml.twig",
+        ],
+    },
 ];
 
 function hasPragma(/* text */) {
@@ -38,8 +43,8 @@ const parsers = {
         astFormat: "melody",
         hasPragma,
         locStart,
-        locEnd
-    }
+        locEnd,
+    },
 };
 
 function canAttachComment(node) {
@@ -69,8 +74,8 @@ const printers = {
         printComment,
         canAttachComment,
         massageAstNode: clean,
-        willPrintOwnComments: () => true
-    }
+        willPrintOwnComments: () => true,
+    },
 };
 
 const options = {
@@ -80,53 +85,53 @@ const options = {
         array: true,
         default: [{ value: [] }],
         description:
-            "Provide additional plugins for Melody. Relative file path from the project root."
+            "Provide additional plugins for Melody. Relative file path from the project root.",
     },
     twigMultiTags: {
         type: "path",
         category: "Global",
         array: true,
         default: [{ value: [] }],
-        description: "Make custom Twig tags known to the parser."
+        description: "Make custom Twig tags known to the parser.",
     },
     twigSingleQuote: {
         type: "boolean",
         category: "Global",
         default: true,
-        description: "Use single quotes in Twig files?"
+        description: "Use single quotes in Twig files?",
     },
     twigAlwaysBreakObjects: {
         type: "boolean",
         category: "Global",
         default: true,
-        description: "Should objects always break in Twig files?"
+        description: "Should objects always break in Twig files?",
     },
     twigPrintWidth: {
         type: "int",
         category: "Global",
         default: 80,
-        description: "Print width for Twig files"
+        description: "Print width for Twig files",
     },
     twigFollowOfficialCodingStandards: {
         type: "boolean",
         category: "Global",
         default: true,
         description:
-            "See https://twig.symfony.com/doc/2.x/coding_standards.html"
+            "See https://twig.symfony.com/doc/2.x/coding_standards.html",
     },
     twigOutputEndblockName: {
         type: "boolean",
         category: "Global",
         default: false,
-        description: "Output the Twig block name in the 'endblock' tag"
-    }
+        description: "Output the Twig block name in the 'endblock' tag",
+    },
 };
 
 const pluginExports = {
     languages,
     printers,
     parsers,
-    options
+    options,
 };
 const combinedExports = Object.assign(
     {},

--- a/src/index.js
+++ b/src/index.js
@@ -17,12 +17,12 @@ const languages = [
         extensions: [".melody.twig", ".html.twig", ".twig"],
         linguistLanguageId: 0,
         vscodeLanguageIds: [
-            "twig",
-            "html.twig",
-            "html.twig.js.css",
-            "xml.twig",
-        ],
-    },
+            "twig", 
+            "html.twig", 
+            "html.twig.js.css", 
+            "xml.twig"
+        ]
+    }
 ];
 
 function hasPragma(/* text */) {
@@ -43,8 +43,8 @@ const parsers = {
         astFormat: "melody",
         hasPragma,
         locStart,
-        locEnd,
-    },
+        locEnd
+    }
 };
 
 function canAttachComment(node) {
@@ -74,8 +74,8 @@ const printers = {
         printComment,
         canAttachComment,
         massageAstNode: clean,
-        willPrintOwnComments: () => true,
-    },
+        willPrintOwnComments: () => true
+    }
 };
 
 const options = {
@@ -85,53 +85,53 @@ const options = {
         array: true,
         default: [{ value: [] }],
         description:
-            "Provide additional plugins for Melody. Relative file path from the project root.",
+            "Provide additional plugins for Melody. Relative file path from the project root."
     },
     twigMultiTags: {
         type: "path",
         category: "Global",
         array: true,
         default: [{ value: [] }],
-        description: "Make custom Twig tags known to the parser.",
+        description: "Make custom Twig tags known to the parser."
     },
     twigSingleQuote: {
         type: "boolean",
         category: "Global",
         default: true,
-        description: "Use single quotes in Twig files?",
+        description: "Use single quotes in Twig files?"
     },
     twigAlwaysBreakObjects: {
         type: "boolean",
         category: "Global",
         default: true,
-        description: "Should objects always break in Twig files?",
+        description: "Should objects always break in Twig files?"
     },
     twigPrintWidth: {
         type: "int",
         category: "Global",
         default: 80,
-        description: "Print width for Twig files",
+        description: "Print width for Twig files"
     },
     twigFollowOfficialCodingStandards: {
         type: "boolean",
         category: "Global",
         default: true,
         description:
-            "See https://twig.symfony.com/doc/2.x/coding_standards.html",
+            "See https://twig.symfony.com/doc/2.x/coding_standards.html"
     },
     twigOutputEndblockName: {
         type: "boolean",
         category: "Global",
         default: false,
-        description: "Output the Twig block name in the 'endblock' tag",
-    },
+        description: "Output the Twig block name in the 'endblock' tag"
+    }
 };
 
 const pluginExports = {
     languages,
     printers,
     parsers,
-    options,
+    options
 };
 const combinedExports = Object.assign(
     {},

--- a/src/print/BlockStatement.js
+++ b/src/print/BlockStatement.js
@@ -17,11 +17,17 @@ const p = (node, path, print, options) => {
             node.trimRightBlock ? " -%}" : " %}"
         ]);
         const parts = [opener];
-        if (node.body.length > 0) {
+        if (
+          node.body.length === 1 &&
+          node.body[0].type === "PrintTextStatement" &&
+          // .value is a StringLiteral; .value.value is a string.
+          isWhitespaceOnly(node.body[0].value.value)
+        ) {
+          // noop; Opening and closing tag should be on the same line.
+        } else if (node.body.length > 0) {
             const indentedBody = printChildBlock(node, path, print, "body");
-            parts.push(indentedBody);
+            parts.push(indentedBody, hardline);
         }
-        parts.push(hardline);
         parts.push(
             node.trimLeftEndblock ? "{%-" : "{%",
             " endblock",

--- a/src/print/Element.js
+++ b/src/print/Element.js
@@ -47,26 +47,18 @@ const p = (node, path, print) => {
         node.children = removeSurroundingWhitespace(node.children);
 
         const childGroups = printChildGroups(node, path, print, "children");
+        const hasChildren = childGroups.length > 0;
         const closingTag = concat(["</", node.name, ">"]);
-        const result = [openingGroup];
-        const joinedChildren = concat(childGroups);
-        if (isInlineElement(node)) {
-            result.push(indent(concat([softline, joinedChildren])), softline);
-        } else {
-            const childBlock = [];
-            if (childGroups.length > 0) {
-                childBlock.push(hardline);
-            }
-            childBlock.push(joinedChildren);
-            result.push(indent(concat(childBlock)));
-            if (childGroups.length > 0) {
-                result.push(hardline);
-            }
-        }
-        result.push(closingTag);
-
-        return isInlineElement(node) ? group(concat(result)) : concat(result);
-    }
+        const result = [
+          openingGroup,
+          // No newlines between opening and closing tag of empty elements.
+          indent(concat([hasChildren ? softline : "", concat(childGroups)])),
+          ...[hasChildren ? softline : ""],
+          closingTag,
+        ];
+    
+        return group(concat(result));
+      }
 
     return openingGroup;
 };

--- a/src/print/EmbedStatement.js
+++ b/src/print/EmbedStatement.js
@@ -19,6 +19,9 @@ const printOpener = (node, path, print) => {
             indent(concat([line, "with ", path.call(print, "argument")]))
         );
     }
+    if (node.contextFree) {
+      parts.push(" only");
+    }
     parts.push(concat([line, node.trimRightEmbed ? "-%}" : "%}"]));
     return group(concat(parts));
 };


### PR DESCRIPTION
vim syntax highlighting plugins do set the filetype to a mix of html and twig. there is no single "twig" filetype like in vscode because of how syntax highlighting works in vim. 

this fix enables the following vim-plugins to work with this plugin
[vim-prettier](https://github.com/prettier/vim-prettier)
[coc-prettier](https://github.com/neoclide/coc-prettier)

here are samples of how the language-id is set in vim-syntax plugins
[nelseyung/twig.vim](https://github.com/nelsyeung/twig.vim/blob/014cd47d795351f0f19f48323a3399831842d295/ftdetect/twig.vim#L2)
[sheerun/vim-polyglot](https://github.com/sheerun/vim-polyglot/blob/c794f186c0a618d2d4cdd5445d9ff20e6f640762/autoload/polyglot/init.vim#L1917)